### PR TITLE
Preparing for refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ build.gradle
 .settings
 bin/
 build/
-
-#Other
-.ahcn

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build.gradle
 .settings
 bin/
 build/
+
+#Other
+.ahcn

--- a/module.txt
+++ b/module.txt
@@ -15,4 +15,7 @@
         }
     ],
     "serverSideOnly" : false
+    "isGameplay" : "true",
+    "defaultWorldGenerator" : "GooeyDefence:gooeyDefenceField"
 }
+

--- a/module.txt
+++ b/module.txt
@@ -15,7 +15,5 @@
         }
     ],
     "serverSideOnly" : false
-    "isGameplay" : "true",
-    "defaultWorldGenerator" : "GooeyDefence:gooeyDefenceField"
 }
 

--- a/src/main/java/org/terasology/flexiblemovement/debug/FlexibleMovementDebugRenderSystem.java
+++ b/src/main/java/org/terasology/flexiblemovement/debug/FlexibleMovementDebugRenderSystem.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.flexiblemovement.debug;
 
-import com.google.common.collect.Lists;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -24,13 +23,11 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.flexiblemovement.FlexibleMovementComponent;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 import org.terasology.rendering.world.selection.BlockSelectionRenderer;
 import org.terasology.utilities.Assets;
 
-import java.util.List;
 
 @RegisterSystem(RegisterMode.CLIENT)
 @Share(FlexibleMovementDebugRenderSystem.class)
@@ -67,13 +64,9 @@ public class FlexibleMovementDebugRenderSystem extends BaseComponentSystem imple
 
     }
 
-    @Override
-    public void renderFirstPerson() {
-
-    }
-
-    @Override
+    @Override @Deprecated
     public void renderShadows() {
 
     }
+
 }

--- a/src/main/java/org/terasology/flexiblemovement/node/FindDummyPathToNode.java
+++ b/src/main/java/org/terasology/flexiblemovement/node/FindDummyPathToNode.java
@@ -17,9 +17,9 @@ package org.terasology.flexiblemovement.node;
 
 import org.terasology.flexiblemovement.FlexibleMovementComponent;
 import org.terasology.flexiblepathfinding.PathfinderSystem;
-import org.terasology.logic.behavior.tree.Node;
-import org.terasology.logic.behavior.tree.Status;
-import org.terasology.logic.behavior.tree.Task;
+//import org.terasology.logic.behavior.tree.Node;
+//import org.terasology.logic.behavior.tree.Status;
+//import org.terasology.logic.behavior.tree.Task;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
@@ -32,41 +32,44 @@ import java.util.Arrays;
  * Meant as a cheap fallback when full pathing is not needed or possible
  * SUCCESS: Always
  */
-public class FindDummyPathToNode extends Node {
-    @Override
-    public FindDummyPathToTask createTask() {
-        return new FindDummyPathToTask(this);
-    }
-    public static class FindDummyPathToTask extends Task{
-        @In
-        PathfinderSystem system;
+public class FindDummyPathToNode {
 
-        @In
-        private WorldProvider world;
-
-        protected FindDummyPathToTask(Node node) {
-            super(node);
-        }
-
-        @Override
-        public Status update(float dt) {
-
-            FlexibleMovementComponent movement = actor().getComponent(FlexibleMovementComponent.class);
-            Vector3i goal = actor().getComponent(FlexibleMovementComponent.class).getPathGoal();
-
-            if(goal == null) {
-                return Status.FAILURE;
-            }
-
-            movement.setPath(Arrays.asList(goal));
-            actor().save(movement);
-
-            return Status.SUCCESS;
-        }
-
-        @Override
-        public void handle(Status result) {
-
-        }
-    }
 }
+//public class FindDummyPathToNode extends Node {
+//    @Override
+//    public FindDummyPathToTask createTask() {
+//        return new FindDummyPathToTask(this);
+//    }
+//    public static class FindDummyPathToTask extends Task{
+//        @In
+//        PathfinderSystem system;
+//
+//        @In
+//        private WorldProvider world;
+//
+//        protected FindDummyPathToTask(Node node) {
+//            super(node);
+//        }
+//
+//        @Override
+//        public Status update(float dt) {
+//
+//            FlexibleMovementComponent movement = actor().getComponent(FlexibleMovementComponent.class);
+//            Vector3i goal = actor().getComponent(FlexibleMovementComponent.class).getPathGoal();
+//
+//            if(goal == null) {
+//                return Status.FAILURE;
+//            }
+//
+//            movement.setPath(Arrays.asList(goal));
+//            actor().save(movement);
+//
+//            return Status.SUCCESS;
+//        }
+//
+//        @Override
+//        public void handle(Status result) {
+//
+//        }
+//    }
+//}

--- a/src/main/java/org/terasology/flexiblemovement/node/FindPathToNode.java
+++ b/src/main/java/org/terasology/flexiblemovement/node/FindPathToNode.java
@@ -21,9 +21,12 @@ import org.terasology.flexiblemovement.system.PluginSystem;
 import org.terasology.flexiblepathfinding.JPSConfig;
 import org.terasology.flexiblepathfinding.PathfinderCallback;
 import org.terasology.flexiblepathfinding.PathfinderSystem;
-import org.terasology.logic.behavior.tree.Node;
-import org.terasology.logic.behavior.tree.Status;
-import org.terasology.logic.behavior.tree.Task;
+//import org.terasology.logic.behavior.tree.Node;
+import org.terasology.logic.behavior.core.ActionNode;
+import org.terasology.logic.behavior.core.BehaviorState;
+//import org.terasology.logic.behavior.tree.Task;
+import org.terasology.logic.behavior.core.ActionNode;
+import org.terasology.logic.behavior.Interpreter;
 import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3i;
@@ -37,75 +40,78 @@ import java.util.List;
  * SUCCESS: When the pathfinder returns a valid path
  * FAILURE: When the pathfinder returns a failure or invalid path
  */
-public class FindPathToNode extends Node {
-    @Override
-    public FindPathToTask createTask() {
-        return new FindPathToTask(this);
-    }
+public class FindPathToNode {
 
-    public class FindPathToTask extends Task {
-        Status pathStatus = null;
-        List<Vector3i> pathResult = null;
-        @In
-        PathfinderSystem pathfinderSystem;
-
-        @In
-        PluginSystem pluginSystem;
-
-        protected FindPathToTask(Node node) {
-            super(node);
-        }
-
-        @Override
-        public Status update(float dt) {
-            if(pathStatus == null) {
-                pathStatus = Status.RUNNING;
-                FlexibleMovementComponent flexibleMovementComponent = actor().getComponent(FlexibleMovementComponent.class);
-                CharacterMovementComponent characterMovementComponent = actor().getComponent(CharacterMovementComponent.class);
-                Vector3i start = FlexibleMovementHelper.posToBlock(actor().getComponent(LocationComponent.class).getWorldPosition());
-                Vector3i goal = actor().getComponent(FlexibleMovementComponent.class).getPathGoal();
-
-                if (start == null || goal == null) {
-                    return Status.FAILURE;
-                }
-
-                JPSConfig config = new JPSConfig(start, goal);
-                config.useLineOfSight = false;
-                config.maxTime = 0.25f;
-                config.maxDepth = 150;
-                config.goalDistance = flexibleMovementComponent.pathGoalDistance;
-                config.plugin = pluginSystem.getMovementPlugin(actor().getEntity()).getJpsPlugin(actor().getEntity());
-
-                pathfinderSystem.requestPath(config, new PathfinderCallback() {
-                    @Override
-                    public void pathReady(List<Vector3i> path, Vector3i target) {
-                        if(path == null || path.size() == 0) {
-                            pathStatus = Status.FAILURE;
-                            return;
-                        }
-                        pathStatus = Status.SUCCESS;
-                        pathResult = path;
-                    }
-                });
-            }
-
-            if(pathStatus == Status.SUCCESS) {
-                FlexibleMovementComponent movement = actor().getComponent(FlexibleMovementComponent.class);
-
-                // PF System returns paths including the starting point.
-                // Since we don't need to move to where we started, we remove the first point in the path
-                pathResult.remove(0);
-
-                movement.setPath(pathResult);
-                actor().save(movement);
-            }
-
-            return pathStatus;
-        }
-
-        @Override
-        public void handle(Status result) {
-
-        }
-    }
 }
+//public class FindPathToNode extends Node {
+//    @Override
+//    public FindPathToTask createTask() {
+//        return new FindPathToTask(this);
+//    }
+//
+//    public class FindPathToTask extends Task {
+//        BehaviorState pathStatus = null;
+//        List<Vector3i> pathResult = null;
+//        @In
+//        PathfinderSystem pathfinderSystem;
+//
+//        @In
+//        PluginSystem pluginSystem;
+//
+//        protected FindPathToTask(Node node) {
+//            super(node);
+//        }
+//
+//        @Override
+//        public BehaviorState update(float dt) {
+//            if(pathStatus == null) {
+//                pathStatus = BehaviorState.RUNNING;
+//                FlexibleMovementComponent flexibleMovementComponent = actor().getComponent(FlexibleMovementComponent.class);
+//                CharacterMovementComponent characterMovementComponent = actor().getComponent(CharacterMovementComponent.class);
+//                Vector3i start = FlexibleMovementHelper.posToBlock(actor().getComponent(LocationComponent.class).getWorldPosition());
+//                Vector3i goal = actor().getComponent(FlexibleMovementComponent.class).getPathGoal();
+//
+//                if (start == null || goal == null) {
+//                    return BehaviorState.FAILURE;
+//                }
+//
+//                JPSConfig config = new JPSConfig(start, goal);
+//                config.useLineOfSight = false;
+//                config.maxTime = 0.25f;
+//                config.maxDepth = 150;
+//                config.goalDistance = flexibleMovementComponent.pathGoalDistance;
+//                config.plugin = pluginSystem.getMovementPlugin(actor().getEntity()).getJpsPlugin(actor().getEntity());
+//
+//                pathfinderSystem.requestPath(config, new PathfinderCallback() {
+//                    @Override
+//                    public void pathReady(List<Vector3i> path, Vector3i target) {
+//                        if(path == null || path.size() == 0) {
+//                            pathStatus = BehaviorState.FAILURE;
+//                            return;
+//                        }
+//                        pathStatus = BehaviorState.SUCCESS;
+//                        pathResult = path;
+//                    }
+//                });
+//            }
+//
+//            if(pathStatus == BehaviorState.SUCCESS) {
+//                FlexibleMovementComponent movement = actor().getComponent(FlexibleMovementComponent.class);
+//
+//                // PF System returns paths including the starting point.
+//                // Since we don't need to move to where we started, we remove the first point in the path
+//                pathResult.remove(0);
+//
+//                movement.setPath(pathResult);
+//                actor().save(movement);
+//            }
+//
+//            return pathStatus;
+//        }
+//
+//        @Override
+//        public void handle(BehaviorState result) {
+//
+//        }
+//    }
+//}

--- a/src/main/java/org/terasology/flexiblemovement/node/MoveAlongPathNode.java
+++ b/src/main/java/org/terasology/flexiblemovement/node/MoveAlongPathNode.java
@@ -16,10 +16,10 @@
 package org.terasology.flexiblemovement.node;
 
 import org.terasology.flexiblemovement.FlexibleMovementComponent;
-import org.terasology.logic.behavior.tree.DecoratorNode;
-import org.terasology.logic.behavior.tree.Node;
-import org.terasology.logic.behavior.tree.Status;
-import org.terasology.logic.behavior.tree.Task;
+//import org.terasology.logic.behavior.tree.DecoratorNode;
+//import org.terasology.logic.behavior.tree.Node;
+//import org.terasology.logic.behavior.tree.Status;
+//import org.terasology.logic.behavior.tree.Task;
 import org.terasology.math.geom.Vector3i;
 
 /**
@@ -31,45 +31,48 @@ import org.terasology.math.geom.Vector3i;
  * 4. On child FAILURE, returns FAILURE
  * 5. When end of path is reached, returns SUCCESS
  */
-public class MoveAlongPathNode extends DecoratorNode {
-    @Override
-    public MoveAlongPathTask createTask() {
-        return new MoveAlongPathTask(this);
-    }
+public class MoveAlongPathNode {
 
-    public class MoveAlongPathTask extends Task {
-        protected MoveAlongPathTask(Node node) {
-            super(node);
-        }
-
-        @Override
-        public void onInitialize() {
-            start(getChild());
-        }
-
-        @Override
-        public Status update(float dt) {
-            return Status.RUNNING;
-        }
-
-        @Override
-        public void handle(Status result) {
-            FlexibleMovementComponent movement = actor().getComponent(FlexibleMovementComponent.class);
-            if(result == Status.SUCCESS) {
-                movement.advancePath();
-                if(movement.isPathFinished()) {
-                    movement.resetPath();
-                    stop(Status.SUCCESS);
-                } else {
-                    start(getChild());
-                }
-            }
-
-            if(result == Status.FAILURE) {
-                stop(Status.FAILURE);
-            }
-
-            actor().save(movement);
-        }
-    }
 }
+//public class MoveAlongPathNode extends DecoratorNode {
+//    @Override
+//    public MoveAlongPathTask createTask() {
+//        return new MoveAlongPathTask(this);
+//    }
+//
+//    public class MoveAlongPathTask extends Task {
+//        protected MoveAlongPathTask(Node node) {
+//            super(node);
+//        }
+//
+//        @Override
+//        public void onInitialize() {
+//            start(getChild());
+//        }
+//
+//        @Override
+//        public Status update(float dt) {
+//            return Status.RUNNING;
+//        }
+//
+//        @Override
+//        public void handle(Status result) {
+//            FlexibleMovementComponent movement = actor().getComponent(FlexibleMovementComponent.class);
+//            if(result == Status.SUCCESS) {
+//                movement.advancePath();
+//                if(movement.isPathFinished()) {
+//                    movement.resetPath();
+//                    stop(Status.SUCCESS);
+//                } else {
+//                    start(getChild());
+//                }
+//            }
+//
+//            if(result == Status.FAILURE) {
+//                stop(Status.FAILURE);
+//            }
+//
+//            actor().save(movement);
+//        }
+//    }
+//}

--- a/src/main/java/org/terasology/flexiblemovement/node/MoveToNode.java
+++ b/src/main/java/org/terasology/flexiblemovement/node/MoveToNode.java
@@ -24,9 +24,9 @@ import org.terasology.flexiblemovement.plugin.WalkingMovementPlugin;
 import org.terasology.flexiblemovement.system.FlexibleMovementSystem;
 import org.terasology.flexiblemovement.system.PluginSystem;
 import org.terasology.flexiblemovement.plugin.MovementPlugin;
-import org.terasology.logic.behavior.tree.Node;
-import org.terasology.logic.behavior.tree.Status;
-import org.terasology.logic.behavior.tree.Task;
+//import org.terasology.logic.behavior.tree.Node;
+//import org.terasology.logic.behavior.tree.Status;
+//import org.terasology.logic.behavior.tree.Task;
 import org.terasology.logic.characters.CharacterMoveInputEvent;
 import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.location.LocationComponent;
@@ -40,78 +40,81 @@ import org.terasology.world.WorldProvider;
  * SUCCESS: When the actor reaches FlexibleMovementComponent.target
  * FAILURE: When the actor believes it is unable to reach its immediate target
  */
-public class MoveToNode extends Node {
-    static final private Logger logger = LoggerFactory.getLogger(MoveToNodeTask.class);
+public class MoveToNode {
 
-    @Override
-    public MoveToNodeTask createTask() {
-        return new MoveToNodeTask(this);
-    }
-
-    public class MoveToNodeTask extends Task {
-        @In private Time time;
-        @In private WorldProvider world;
-        @In private FlexibleMovementSystem flexibleMovementSystem;
-        @In private PluginSystem pluginSystem;
-
-        public MoveToNodeTask(Node node) {
-            super(node);
-        }
-
-        @Override
-        public Status update(float dt) {
-            LocationComponent location = actor().getComponent(LocationComponent.class);
-            FlexibleMovementComponent flexibleMovementComponent = actor().getComponent(FlexibleMovementComponent.class);
-            CharacterMovementComponent characterMovementComponent = actor().getComponent(CharacterMovementComponent.class);
-
-            // we need to translate the movement target to an expected real world position
-            // in practice we just need to adjust the Y so that it's resting on top of the block at the right height
-            Vector3f adjustedMoveTarget = flexibleMovementComponent.target.toVector3f();
-
-            // this is the result of experimentation and some penwork
-//            float adjustedY = (float) Math.ceil(adjustedMoveTarget.y - halfHeight) + halfHeight - 0.5f;
-//            adjustedMoveTarget.setY(adjustedY);
-
-            Vector3f position = location.getWorldPosition();
-            if (position.distance(adjustedMoveTarget) <= flexibleMovementComponent.targetTolerance) {
-                return Status.SUCCESS;
-            }
-
-            flexibleMovementComponent.sequenceNumber++;
-            MovementPlugin plugin = pluginSystem.getMovementPlugin(actor().getEntity());
-            CharacterMoveInputEvent result = plugin.move(
-                    actor().getEntity(),
-                    adjustedMoveTarget,
-                    flexibleMovementComponent.sequenceNumber
-            );
-
-            if (result == null) {
-                // this is ugly, but due to unknown idiosyncrasies in the engine character movement code, characters
-                // sometimes sink into solid blocks below them. This causes reachability checks to fail intermittently,
-                // especially when characters stop moving. In an ideal world, we'd exit failure here to indicate our
-                // path is no longer valid. However, we instead fall back to a default movement plugin in the hopes
-                // that a gentle nudge in a probably-correct direction will at least make the physics reconcile the
-                // intersection, and hopefully return to properly penetrable blocks.
-                logger.debug("Movement plugin returned null");
-                MovementPlugin fallbackPlugin = new WalkingMovementPlugin(world, time);
-                result = fallbackPlugin.move(
-                        actor().getEntity(),
-                        adjustedMoveTarget,
-                        flexibleMovementComponent.sequenceNumber
-                );
-            }
-
-            actor().getEntity().send(result);
-            flexibleMovementComponent.lastInput = time.getGameTimeInMs();
-            flexibleMovementComponent.collidedHorizontally = false;
-            actor().save(flexibleMovementComponent);
-
-            return Status.RUNNING;
-        }
-
-        @Override
-        public void handle(Status result) {
-
-        }
-    }
 }
+//public class MoveToNode extends Node {
+//    static final private Logger logger = LoggerFactory.getLogger(MoveToNodeTask.class);
+//
+//    @Override
+//    public MoveToNodeTask createTask() {
+//        return new MoveToNodeTask(this);
+//    }
+//
+//    public class MoveToNodeTask extends Task {
+//        @In private Time time;
+//        @In private WorldProvider world;
+//        @In private FlexibleMovementSystem flexibleMovementSystem;
+//        @In private PluginSystem pluginSystem;
+//
+//        public MoveToNodeTask(Node node) {
+//            super(node);
+//        }
+//
+//        @Override
+//        public Status update(float dt) {
+//            LocationComponent location = actor().getComponent(LocationComponent.class);
+//            FlexibleMovementComponent flexibleMovementComponent = actor().getComponent(FlexibleMovementComponent.class);
+//            CharacterMovementComponent characterMovementComponent = actor().getComponent(CharacterMovementComponent.class);
+//
+//            // we need to translate the movement target to an expected real world position
+//            // in practice we just need to adjust the Y so that it's resting on top of the block at the right height
+//            Vector3f adjustedMoveTarget = flexibleMovementComponent.target.toVector3f();
+//
+//            // this is the result of experimentation and some penwork
+////            float adjustedY = (float) Math.ceil(adjustedMoveTarget.y - halfHeight) + halfHeight - 0.5f;
+////            adjustedMoveTarget.setY(adjustedY);
+//
+//            Vector3f position = location.getWorldPosition();
+//            if (position.distance(adjustedMoveTarget) <= flexibleMovementComponent.targetTolerance) {
+//                return Status.SUCCESS;
+//            }
+//
+//            flexibleMovementComponent.sequenceNumber++;
+//            MovementPlugin plugin = pluginSystem.getMovementPlugin(actor().getEntity());
+//            CharacterMoveInputEvent result = plugin.move(
+//                    actor().getEntity(),
+//                    adjustedMoveTarget,
+//                    flexibleMovementComponent.sequenceNumber
+//            );
+//
+//            if (result == null) {
+//                // this is ugly, but due to unknown idiosyncrasies in the engine character movement code, characters
+//                // sometimes sink into solid blocks below them. This causes reachability checks to fail intermittently,
+//                // especially when characters stop moving. In an ideal world, we'd exit failure here to indicate our
+//                // path is no longer valid. However, we instead fall back to a default movement plugin in the hopes
+//                // that a gentle nudge in a probably-correct direction will at least make the physics reconcile the
+//                // intersection, and hopefully return to properly penetrable blocks.
+//                logger.debug("Movement plugin returned null");
+//                MovementPlugin fallbackPlugin = new WalkingMovementPlugin(world, time);
+//                result = fallbackPlugin.move(
+//                        actor().getEntity(),
+//                        adjustedMoveTarget,
+//                        flexibleMovementComponent.sequenceNumber
+//                );
+//            }
+//
+//            actor().getEntity().send(result);
+//            flexibleMovementComponent.lastInput = time.getGameTimeInMs();
+//            flexibleMovementComponent.collidedHorizontally = false;
+//            actor().save(flexibleMovementComponent);
+//
+//            return Status.RUNNING;
+//        }
+//
+//        @Override
+//        public void handle(Status result) {
+//
+//        }
+//    }
+//}

--- a/src/main/java/org/terasology/flexiblemovement/node/ValidatePathNode.java
+++ b/src/main/java/org/terasology/flexiblemovement/node/ValidatePathNode.java
@@ -20,9 +20,9 @@ import org.terasology.flexiblemovement.system.FlexibleMovementSystem;
 import org.terasology.flexiblemovement.system.PluginSystem;
 import org.terasology.flexiblepathfinding.PathfinderSystem;
 import org.terasology.flexiblepathfinding.plugins.JPSPlugin;
-import org.terasology.logic.behavior.tree.Node;
-import org.terasology.logic.behavior.tree.Status;
-import org.terasology.logic.behavior.tree.Task;
+//import org.terasology.logic.behavior.tree.Node;
+//import org.terasology.logic.behavior.tree.Status;
+//import org.terasology.logic.behavior.tree.Task;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 
@@ -33,43 +33,46 @@ import java.util.List;
  * SUCCESS: when there are no unwalkable waypoints
  * FAILURE: otherwise
  */
-public class ValidatePathNode extends Node {
+public class ValidatePathNode {
 
-    @Override
-    public ValidatePathNode.ValidatePathTask createTask() {
-        return new ValidatePathNode.ValidatePathTask(this);
-    }
-
-    public class ValidatePathTask extends Task{
-        Status pathStatus = null;
-        List<Vector3i> pathResult = null;
-        @In private PathfinderSystem system;
-        @In private PluginSystem pluginSystem;
-        @In private FlexibleMovementSystem flexibleMovementSystem;
-
-        protected ValidatePathTask(Node node) {
-            super(node);
-        }
-
-        @Override
-        public Status update(float dt) {
-            FlexibleMovementComponent flexibleMovementComponent = actor().getComponent(FlexibleMovementComponent.class);
-            JPSPlugin pathfindingPlugin = pluginSystem.getMovementPlugin(actor().getEntity()).getJpsPlugin(actor().getEntity());
-            if(flexibleMovementComponent == null || pathfindingPlugin == null) {
-                return Status.FAILURE;
-            }
-
-//            for(Vector3i pos : actor().getComponent(FlexibleMovementComponent.class).getPath()) {
-//                if(!pathfindingPlugin.isWalkable(pos)) {
-//                    return Status.FAILURE;
-//                }
-//            }
-            return Status.SUCCESS;
-        }
-
-        @Override
-        public void handle(Status result) {
-
-        }
-    }
 }
+//public class ValidatePathNode extends Node {
+//
+//    @Override
+//    public ValidatePathNode.ValidatePathTask createTask() {
+//        return new ValidatePathNode.ValidatePathTask(this);
+//    }
+//
+//    public class ValidatePathTask extends Task{
+//        Status pathStatus = null;
+//        List<Vector3i> pathResult = null;
+//        @In private PathfinderSystem system;
+//        @In private PluginSystem pluginSystem;
+//        @In private FlexibleMovementSystem flexibleMovementSystem;
+//
+//        protected ValidatePathTask(Node node) {
+//            super(node);
+//        }
+//
+//        @Override
+//        public Status update(float dt) {
+//            FlexibleMovementComponent flexibleMovementComponent = actor().getComponent(FlexibleMovementComponent.class);
+//            JPSPlugin pathfindingPlugin = pluginSystem.getMovementPlugin(actor().getEntity()).getJpsPlugin(actor().getEntity());
+//            if(flexibleMovementComponent == null || pathfindingPlugin == null) {
+//                return Status.FAILURE;
+//            }
+//
+////            for(Vector3i pos : actor().getComponent(FlexibleMovementComponent.class).getPath()) {
+////                if(!pathfindingPlugin.isWalkable(pos)) {
+////                    return Status.FAILURE;
+////                }
+////            }
+//            return Status.SUCCESS;
+//        }
+//
+//        @Override
+//        public void handle(Status result) {
+//
+//        }
+//    }
+//}

--- a/src/main/java/org/terasology/flexiblemovement/plugin/FlyingMovementPlugin.java
+++ b/src/main/java/org/terasology/flexiblemovement/plugin/FlyingMovementPlugin.java
@@ -55,7 +55,7 @@ public class FlyingMovementPlugin extends MovementPlugin {
             entity.send(new SetMovementModeEvent(MovementMode.FLYING));
         }
 
-        return new CharacterMoveInputEvent(sequence, pitch, yaw, delta, false, true, dt);
+        return new CharacterMoveInputEvent(sequence, pitch, yaw, delta, false, false,true, dt);
     }
 
     private float getPitch(Vector3f delta) {

--- a/src/main/java/org/terasology/flexiblemovement/plugin/LeapingMovementPlugin.java
+++ b/src/main/java/org/terasology/flexiblemovement/plugin/LeapingMovementPlugin.java
@@ -50,6 +50,6 @@ public class LeapingMovementPlugin extends MovementPlugin {
         long dt = getTime().getGameDeltaInMs();
 
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
-        return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, true, dt);
+        return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, false,true, dt);
     }
 }

--- a/src/main/java/org/terasology/flexiblemovement/plugin/SwimmingMovementPlugin.java
+++ b/src/main/java/org/terasology/flexiblemovement/plugin/SwimmingMovementPlugin.java
@@ -50,7 +50,7 @@ public class SwimmingMovementPlugin extends MovementPlugin {
         float pitch = getPitch(delta);
 
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
-        return new CharacterMoveInputEvent(sequence, pitch, yaw, delta, false, movement.grounded, dt);
+        return new CharacterMoveInputEvent(sequence, pitch, yaw, delta, false, false, movement.grounded, dt);
     }
 
     private float getPitch(Vector3f delta) {

--- a/src/main/java/org/terasology/flexiblemovement/plugin/WalkingMovementPlugin.java
+++ b/src/main/java/org/terasology/flexiblemovement/plugin/WalkingMovementPlugin.java
@@ -50,6 +50,6 @@ public class WalkingMovementPlugin extends MovementPlugin {
         long dt = getTime().getGameDeltaInMs();
 
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
-        return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, false, dt);
+        return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, false,false, dt);
     }
 }


### PR DESCRIPTION
## Goals
The idea behind this PR is to prepare FlexibleMovement for refactoring in order to support the new BehaviorTree structure. The changes made at this point were only intended to make the code compilable again (with some minor warning supressing).

## Changes
### Modifications

- Deprecated methods/constructors changed for warning suppression. Classes affected:
   - LeapingMovementPlugin
   - WalkingMovementPlugin
   - SwimmingMovementPlugin
   - FlyingMovementPlugin
- Removed invalid imports (referring to the old behavior structure) and commented all classes under org.terasology.flexiblemovement.node since they were not being directly used by the module / preventing the module compilation.

## Todo

- [ ] Re-implement commented classes using the new BehaviorTree (BT) structure. The old structure was based on the Node / Task / Status tuple. While the previous Status class can be directly translated to BehaviorState, the Node / Task logic should be changed to reflect the new BT.

- [ ] The original testbed made by @kaen could also be refactored and incorporated into the module (similarly to how it's done in GooeyDefence), for the benefit of new contributors / mantainers.
